### PR TITLE
 Fix mismatch in running style tags

### DIFF
--- a/auto_derby/scenes/paddock.py
+++ b/auto_derby/scenes/paddock.py
@@ -23,10 +23,10 @@ class PaddockScene(Scene):
     def choose_runing_style(self, style: RuningStyle):
         rp = action.resize_proxy()
         button_pos = {
-            RuningStyle.LEAD: rp.vector2((60, 500), 466),
-            RuningStyle.HEAD: rp.vector2((160, 500), 466),
-            RuningStyle.MIDDLE: rp.vector2((260, 500), 466),
-            RuningStyle.LAST: rp.vector2((360, 500), 466),
+            RuningStyle.LEAD: rp.vector2((360, 500), 466),
+            RuningStyle.HEAD: rp.vector2((260, 500), 466),
+            RuningStyle.MIDDLE: rp.vector2((160, 500), 466),
+            RuningStyle.LAST: rp.vector2((60, 500), 466),
         }[style]
         action.tap_image(templates.RACE_RUNNING_STYLE_CHANGE_BUTTON)
         _, pos = action.wait_image(templates.RACE_CONFIRM_BUTTON)

--- a/auto_derby/single_mode/commands/race.py
+++ b/auto_derby/single_mode/commands/race.py
@@ -19,10 +19,11 @@ _LOGGER = logging.getLogger(__name__)
 
 def _choose_running_style(ctx: Context, race1: Race) -> None:
     scene = PaddockScene.enter(ctx)
-    action.wait_tap_image(templates.RACE_RUNNING_STYLE_CHANGE_BUTTON)
     scores = race1.style_scores(ctx)
 
-    style_scores = sorted(zip(RuningStyle, scores), key=lambda x: x[1], reverse=True)
+    style_scores = sorted(
+        zip(RuningStyle, reversed(scores)), key=lambda x: x[1], reverse=True
+    )
 
     for style, score in style_scores:
         _LOGGER.info("running style score:\t%.2f:\t%s", score, style)


### PR DESCRIPTION
The tags are reversed, but `PaddockScene.choose_runing_style()` is also reversed so the 2 mistakes cancel each other. The only observable problem then is the logs which print the tags wrongly.

Not changing interface of `Race.style_scores()` because that would be a breaking change for plugins that override it.

Also removed the line `action.wait_tap_image(templates.RACE_RUNNING_STYLE_CHANGE_BUTTON)` which I think is unnecessary as `PaddockScene.choose_runing_style()` will still press that button anyway. Please let me know if I missed something.