### PR TITLE
recognize climax grade point above 1000

### DIFF
--- a/auto_derby/scenes/single_mode/command.py
+++ b/auto_derby/scenes/single_mode/command.py
@@ -22,7 +22,7 @@ def _recognize_climax_grade_point(ctx: Context):
         ctx.grade_point = 0
         return
     rp = action.resize_proxy()
-    bbox = rp.vector4((10, 185, 111, 218), 540)
+    bbox = rp.vector4((10, 185, 119, 218), 540)
     img = template.screenshot().crop(bbox)
     x, _ = next(
         template.match(


### PR DESCRIPTION
![last_screenshot1000pt](https://user-images.githubusercontent.com/16464896/157639515-343d8a6d-6221-4bb4-89d4-c925e9a2826d.png)
```
DEBUG [2022-03-10 17:32:28]:auto_derby.template:61: load: single_mode_climax_grade_point_pt_text.pos.png
DEBUG [2022-03-10 17:32:28]:auto_derby.template:78: can not load: single_mode_climax_grade_point_pt_text.pos.png: [Errno 2] No such file or directory: 'D:\\dev\\auto-derby\\auto_derby\\templates\\single_mode_climax_grade_point_pt_text.pos.png'
DEBUG [2022-03-10 17:32:28]:auto_derby.template:61: load: single_mode_climax_grade_point_pt_text.png
DEBUG [2022-03-10 17:32:28]:auto_derby.template:179: not match: tmpl=tmpl<single_mode_climax_grade_point_pt_text.png>, pos=(32, 5), similarity=0.629
INFO  [2022-03-10 17:32:28]:auto_derby.template:199: no match: tmpl=(tmpl<single_mode_climax_grade_point_pt_text.png>,)
ERROR [2022-03-10 17:32:28]:__main__:123: unexpected exception
Traceback (most recent call last):
  File "D:\dev\auto-derby\auto_derby\__main__.py", line 119, in <module>
    main()
  File "D:\dev\auto-derby\auto_derby\__main__.py", line 90, in main
    job()
  File "D:\dev\auto-derby\auto_derby\jobs\nurturing.py", line 288, in nurturing
    spec[_spec_key(tmpl)](ac)
  File "D:\dev\auto-derby\auto_derby\jobs\nurturing.py", line 144, in _ac_handle_turn
    _handle_turn(ac.ctx)
  File "D:\dev\auto-derby\auto_derby\jobs\nurturing.py", line 91, in _handle_turn
    scene.recognize(ctx)
  File "D:\dev\auto-derby\auto_derby\scenes\single_mode\command.py", line 194, in recognize
    _recognize_climax_grade_point(ctx)
  File "D:\dev\auto-derby\auto_derby\scenes\single_mode\command.py", line 27, in _recognize_climax_grade_point
    x, _ = next(
StopIteration
```
應該是寬度不足，模板中的空白部分無法在指定範圍內匹配
這個範圍修改至少通過了這張截圖，但不確保如果有更寬的點數時，能不能再次匹配成功