### PR TITLE
fix(adb): not use -d on normal display

### DIFF
--- a/auto_derby/clients/adb.py
+++ b/auto_derby/clients/adb.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import io
 import logging
+from math import floor
 import re
 import time
 from pathlib import Path
@@ -51,7 +52,7 @@ class ADBClient(Client):
 
     def tap(self, point: Tuple[int, int]) -> None:
         x, y = point
-        command = f"input tap {x} {y}"
+        command = f"input -d {self.display_id} tap {x} {y}"
         LOGGER.debug("tap: %s", command)
         res = self.device.shell(command)
         assert not res, res
@@ -63,7 +64,33 @@ class ADBClient(Client):
         )
 
     def load_size(self):
-        res = self.device.shell("wm size")
+        display_string = self.device.shell(
+            f"dumpsys display",
+            decode=True,
+            transport_timeout_s=None,
+        )
+        display_data = re.findall(
+            "^\\s+mUniqueId=(\\w+):(?:(?:(?:\\w+\\.?)+):((?:\\w+\\.?)+):)?(\\d+)$",
+            display_string,
+            re.MULTILINE,
+        )
+        display_id = [
+            item
+            for item in display_data
+            if item[0] == "virtual" and item[1] == "jp.co.cygames.umamusume"
+        ]
+        if len(display_id) == 0:
+            display_id = [
+                item for item in display_data if item[0] == "local" and item[1] == ""
+            ]
+        LOGGER.debug(
+            "screen display: UniqueId=%s:%s:%s",
+            display_id[0][0],
+            display_id[0][1],
+            display_id[0][2],
+        )
+        self.display_id = display_id[0][2]
+        res = self.device.shell(f"wm size -d {self.display_id}")
         match = re.match(r"Physical size: (\d+)x(\d+)", res)
         assert match, "unexpected command result: %s" % res
         self._width = int(match.group(2))
@@ -71,7 +98,17 @@ class ADBClient(Client):
         if self._width > self._height:
             # handle orientation
             self._height, self._width = self._width, self._height
-        LOGGER.debug("screen size: width=%d height=%d", self.width, self.height)
+        LOGGER.debug("screen size: width=%d height=%d", self._width, self._height)
+        self.resize = None
+        # workaround for WSA not perfectly 16:9
+        if (
+            display_id[0][0] == "virtual"
+            and self._width / self._height - 0.5625 < 0.005
+        ):
+            self.resize = (floor(self._height / 16 * 9), self._height)
+            LOGGER.debug(
+                "screen resize: width=%d height=%d", self.resize[0], self.resize[1]
+            )
 
     def _screenshot_init(self) -> PIL.Image.Image:
         screenshot_perf: List[Tuple[Callable[[], PIL.Image.Image], int]] = []
@@ -111,7 +148,7 @@ class ADBClient(Client):
 
     def _screenshot_png(self) -> PIL.Image.Image:
         img_data = self.device.shell(
-            f"screencap -p",
+            f"screencap -d {self.display_id} -p",
             decode=False,
             transport_timeout_s=None,
         )
@@ -121,7 +158,7 @@ class ADBClient(Client):
     def _screenshot_raw(self) -> PIL.Image.Image:
         # https://stackoverflow.com/a/59470924
         img_data = self.device.shell(
-            f"screencap",
+            f"screencap -d {self.display_id}",
             decode=False,
             transport_timeout_s=None,
         )
@@ -141,7 +178,9 @@ class ADBClient(Client):
         self.start_game()
 
     def screenshot(self) -> PIL.Image.Image:
-        return self._screenshot()
+        if self.resize == None:
+            return self._screenshot()
+        return self._screenshot().resize(self.resize)
 
     def swipe(
         self, point: Tuple[int, int], *, dx: int, dy: int, duration: float
@@ -150,7 +189,7 @@ class ADBClient(Client):
         x2, y2 = x1 + dx, y1 + dy
         duration_ms = int(duration * 1e3)
         duration_ms = max(200, duration_ms)  # not work if too fast
-        command = f"input swipe {x1} {y1} {x2} {y2} {duration_ms}"
+        command = f"input -d {self.display_id} swipe {x1} {y1} {x2} {y2} {duration_ms}"
         LOGGER.debug("swipe: %s", command)
         res = self.device.shell(
             command,


### PR DESCRIPTION
提交 Pull Request 前沒有測試好很抱歉，普通模擬器的命令行沒有 -d
暫時用不上的邏輯也移除了，只留下了基本的連接邏輯
可能 WSA 相關的邏輯先用成 draft PR 會好些嗎？
是説雖然 WSA 獨顯跑不了馬娘，WSA 用 Microsoft Basic Render Driver 還是能跑