### PR TITLE
remove needless deepcopy && adept new setting auto-use-item && skip choose same running style in race scence

### DIFF
--- a/auto_derby/constants.py
+++ b/auto_derby/constants.py
@@ -8,6 +8,7 @@ import functools
 
 
 class RunningStyle(enum.Enum):
+    UNKNOWN = 0
     LEAD = 1
     HEAD = 2
     MIDDLE = 3

--- a/auto_derby/scenes/single_mode/item_menu.py
+++ b/auto_derby/scenes/single_mode/item_menu.py
@@ -186,6 +186,11 @@ class ItemMenuScene(Scene):
                 if match.id not in remains:
                     continue
                 if match.disabled:
+                    if match.auto_used():
+                        ctx.items.remove(match.id, remains[match.id])
+                        for _ in range(remains[match.id]):
+                            ctx.item_history.append(ctx, match)
+
                     app.log.text("skip disabled: %s" % match, level=app.WARN)
                     del remains[match.id]
                     continue

--- a/auto_derby/single_mode/commands/race.py
+++ b/auto_derby/single_mode/commands/race.py
@@ -20,7 +20,16 @@ def _choose_running_style(ctx: Context, race1: Race) -> None:
     for style, score in style_scores:
         app.log.text("running style score:\t%.2f:\t%s" % (score, style))
 
-    scene.choose_running_style(style_scores[0][0])
+    style = style_scores[0][0]
+    race1.run_style = style
+    # Skip choosing style if same with previous.
+    try:
+        perv_style = next(ctx.race_history.iterate(last=1))[1].run_style
+        if style == perv_style:
+            return
+    except StopIteration:
+        pass
+    scene.choose_running_style(style)
 
 
 _RACE_ORDER_TEMPLATES = {
@@ -131,9 +140,9 @@ class RaceCommand(Command):
                 break
             app.device.tap(action.template_rect(tmpl, pos))
         ctx.race_turns.add(ctx.turn_count())
-        ctx.race_history.append(ctx, self.race)
 
         _choose_running_style(ctx, race1)
+        ctx.race_history.append(ctx, self.race)
 
         _handle_race_result(ctx, race1)
         ctx.fan_count = 0  # request update in next turn

--- a/auto_derby/single_mode/context.py
+++ b/auto_derby/single_mode/context.py
@@ -19,7 +19,7 @@ from typing import (
 if TYPE_CHECKING:
     from . import go_out
 
-from copy import deepcopy
+import copy
 
 import cast_unknown as cast
 import cv2
@@ -345,6 +345,16 @@ class Context:
         self.items_last_updated_turn = 0
         self.item_history = item.History()
 
+    def clone(self) -> Context:
+        obj = copy.copy(self)
+        obj.conditions = self.conditions.copy()
+        obj.training_levels = self.training_levels.copy()
+        obj.items = self.items.clone()
+        obj.items_last_updated_turn = 0
+        obj.item_history = self.item_history
+
+        return obj
+
     def target_grade_point(self) -> int:
         if self.date[1:] == (0, 0):
             return 0
@@ -640,9 +650,6 @@ class Context:
             d["gradePoint"] = self.grade_point
             d["shopCoin"] = self.shop_coin
         return d
-
-    def clone(self):
-        return deepcopy(self)
 
     @classmethod
     def status_by_name(cls, name: Text) -> Tuple[int, Text]:

--- a/auto_derby/single_mode/item/effect_summary.py
+++ b/auto_derby/single_mode/item/effect_summary.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+import copy
 from collections import defaultdict
-from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -54,6 +54,11 @@ class Buff:
 class BuffList:
     def __init__(self, v: Iterable[Buff] = ()) -> None:
         self._l: List[Buff] = list(v)
+
+    def clone(self) -> BuffList:
+        obj = self.__class__()
+        obj._l = self._l.copy()
+        return obj
 
     def __iter__(self):
         yield from self._l
@@ -133,6 +138,23 @@ class EffectSummary:
         self.unknown_effects: Sequence[Effect] = ()
         self.known_effects: Sequence[Effect] = ()
 
+    def clone(self) -> EffectSummary:
+        obj = copy.copy(self)
+        obj.condition_add = self.condition_add.copy()
+        obj.condition_remove = self.condition_remove.copy()
+        obj.training_levels = self.training_levels.copy()
+        obj.training_effect_buff = self.training_effect_buff.copy()
+        for k, v in obj.training_effect_buff.items():
+            obj.training_effect_buff[k] = v.clone()
+        obj.training_vitality_debuff = self.training_vitality_debuff.copy()
+        for k, v in obj.training_vitality_debuff.items():
+            obj.training_vitality_debuff[k] = v.clone()
+        obj.race_fan_buff = self.race_fan_buff.clone()
+        obj.race_reward_buff = self.race_reward_buff.clone()
+        obj.character_friendship = self.character_friendship.copy()
+
+        return obj
+
     def add(self, item: Item, age: int = 0):
         for effect in item.effects:
             if effect.turn_count < age:
@@ -149,9 +171,6 @@ class EffectSummary:
                     *self.unknown_effects,
                     effect,
                 )
-
-    def clone(self) -> EffectSummary:
-        return deepcopy(self)
 
     def apply_to_training(self, ctx: Context, training: Training) -> Training:
         """

--- a/auto_derby/single_mode/item/item.py
+++ b/auto_derby/single_mode/item/item.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
+import copy
 from typing import TYPE_CHECKING, Any, Dict, Text, Tuple
 
 import numpy as np
@@ -39,6 +39,9 @@ class Item:
         self.price = 0
         self.quantity = 0
         self.disabled = False
+
+    def clone(self) -> Item:
+        return copy.copy(self)
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Item) and self._equal_key() == other._equal_key()
@@ -82,9 +85,6 @@ class Item:
         v.effect_priority = d["effectPriority"]
         v.effects = tuple(Effect.from_dict(i) for i in d["effects"])
         return v
-
-    def clone(self):
-        return deepcopy(self)
 
     def effect_summary(self) -> EffectSummary:
         es = EffectSummary()

--- a/auto_derby/single_mode/item/item.py
+++ b/auto_derby/single_mode/item/item.py
@@ -455,5 +455,15 @@ class Item:
             return False
         return True
 
+    def auto_used(self) -> bool:
+        """auto used item by setting
+        ※自動使用の対象となる育成グッズは、「基礎能力アップ」「トレーニングLvアップ」
+        の効果がある育成グッズです。 see https://dmg.umamusume.jp/news/detail?id=831
+        """
+        es = self.effect_summary()
+        if es.training_levels:
+            return True
+        return (es.speed + es.stamina + es.power + es.guts + es.wisdom) > 0
+
 
 g.item_class = Item

--- a/auto_derby/single_mode/item/item_list.py
+++ b/auto_derby/single_mode/item/item_list.py
@@ -12,6 +12,11 @@ class ItemList:
     def __init__(self) -> None:
         self._m: Dict[int, Item] = {}
 
+    def clone(self) -> ItemList:
+        obj = self.__class__()
+        obj._m = self._m.copy()
+        return obj
+
     def __contains__(self, value: Item) -> bool:
         return self.get(value.id).quantity > 0
 

--- a/auto_derby/single_mode/race/race.py
+++ b/auto_derby/single_mode/race/race.py
@@ -92,6 +92,8 @@ class Race:
 
         self.reward_buff = 0.0
 
+        self.run_style = RunningStyle.UNKNOWN
+
     def clone(self):
         return deepcopy(self)
 

--- a/auto_derby/single_mode/race/race.py
+++ b/auto_derby/single_mode/race/race.py
@@ -2,7 +2,7 @@
 # -*- coding=UTF-8 -*-
 from __future__ import annotations
 
-from copy import deepcopy
+import copy
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Set, Text, Tuple
 
 from auto_derby.constants import RunningStyle
@@ -94,8 +94,8 @@ class Race:
 
         self.run_style = RunningStyle.UNKNOWN
 
-    def clone(self):
-        return deepcopy(self)
+    def clone(self) -> Race:
+        return copy.copy(self)
 
     def to_dict(self) -> Dict[Text, Any]:
         return {

--- a/auto_derby/single_mode/training/training.py
+++ b/auto_derby/single_mode/training/training.py
@@ -2,7 +2,7 @@
 # pyright: strict
 from __future__ import annotations
 
-from copy import deepcopy
+import copy
 from typing import Tuple
 
 from PIL.Image import Image
@@ -49,6 +49,9 @@ class Training:
         self.confirm_position: Tuple[int, int] = (0, 0)
         self.partners: Tuple[Partner, ...] = ()
 
+    def clone(self) -> Training:
+        return copy.copy(self)
+
     def __str__(self):
 
         named_data = (
@@ -79,9 +82,6 @@ class Training:
             ).strip()
             + ">"
         )
-
-    def clone(self):
-        return deepcopy(self)
 
     def score(self, ctx: Context) -> float:
         return training_score.compute(ctx, self)


### PR DESCRIPTION
8626cac133b2a0beeb352d5fe9f57fa940605d07 关于deepcopy的问题, 我把clone里的赋值用 copy.copy()替换了,  这样重复的代码就少一些，其他就保留不变, 关于 auto_derby/single_mode/item/effect_summary.py, 深拷贝好多啊, 感觉可以deepcopy, 就没动了.  

6acc3a12de68ef730c37ce48324d4184ecc324c6 这是因为6/30号 更新加的选项， 开启后巅峰杯自动使用属性书, 设施等级。实际效果是购买完毕了加入动画, 然后进入选择道具界面时, 自动使用的道具置灰, 所以我在置灰条件 `if match.disabled:`, 加入了是否是自动使用道具的判断. 

36187d9f99f9dda92251f48788dc68f24271f9f9 这个是比赛选择跑法的时候，假如和上次比赛跑法相同, 就不会进行选择操作(假如有人中途手动比赛的话, 会出问题..)  在race中多加了比赛的跑法属性,  `self.run_style = RunningStyle.UNKNOWN`  