### PR TITLE
feat: adapt game setting 'auto use item'

### DIFF
--- a/auto_derby/scenes/single_mode/item_menu.py
+++ b/auto_derby/scenes/single_mode/item_menu.py
@@ -186,6 +186,11 @@ class ItemMenuScene(Scene):
                 if match.id not in remains:
                     continue
                 if match.disabled:
+                    if match.auto_used():
+                        ctx.items.remove(match.id, remains[match.id])
+                        for _ in range(remains[match.id]):
+                            ctx.item_history.append(ctx, match)
+
                     app.log.text("skip disabled: %s" % match, level=app.WARN)
                     del remains[match.id]
                     continue

--- a/auto_derby/single_mode/item/item.py
+++ b/auto_derby/single_mode/item/item.py
@@ -455,5 +455,15 @@ class Item:
             return False
         return True
 
+    def auto_used(self) -> bool:
+        """auto used item by setting
+        ※自動使用の対象となる育成グッズは、「基礎能力アップ」「トレーニングLvアップ」
+        の効果がある育成グッズです。 see https://dmg.umamusume.jp/news/detail?id=831
+        """
+        es = self.effect_summary()
+        if es.training_levels:
+            return True
+        return (es.speed + es.stamina + es.power + es.guts + es.wisdom) > 0
+
 
 g.item_class = Item


### PR DESCRIPTION
这是因为6/30号 更新加的选项， 开启后巅峰杯自动使用属性书, 设施等级。实际效果是购买完毕了加入动画, 然后进入选择道具界面时, 自动使用的道具置灰, 所以我在置灰条件 if match.disabled:, 加入了是否是自动使用道具的判断.

https://dmg.umamusume.jp/news/detail?id=831