### PR TITLE
fix: assertion error due to image format

### DIFF
--- a/auto_derby/clients/adb.py
+++ b/auto_derby/clients/adb.py
@@ -134,8 +134,8 @@ class ADBClient(Client):
         # https://developer.android.com/reference/android/graphics/PixelFormat#RGBA_8888
         assert pixel_format == 1, "unsupported pixel format: %s" % pixel_format
         img = PIL.Image.frombuffer(
-            "RGBA", (width, height), img_data[12:], "raw", "RGBX", 0, 1
-        ).convert("RGBA")
+            "RGB", (width, height), img_data[12:], "raw", "RGBX", 0, 1
+        ).convert("RGB")
         return img
 
     def setup(self) -> None:


### PR DESCRIPTION
Fix the error mentioned in https://github.com/NateScarlet/auto-derby/issues/322#issuecomment-1173680185 since alpha channel is unexpected
```
  File "D:\dev\auto-derby\auto_derby\single_mode\context.py", line 107, in _is_empty
    assert v.shape == (3,), v.shape
AssertionError: (4,)
```